### PR TITLE
feat(list): task list --all でプロジェクト横断タスク一覧を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ task done 1
 |---------|------|
 | `task add <タイトル>` | タスクを作成する |
 | `task list` | タスク一覧を表示する |
+| `task list --all` | 全プロジェクト + Inbox のタスクを横断表示する |
 | `task show <id>` | タスクの詳細を表示する |
 | `task start <id>` | タスクを開始する（`in_progress` に変更） |
 | `task done <id>` | タスクを完了にする（`completed` に変更） |
@@ -136,6 +137,7 @@ task list [オプション]
   -s, --status <ステータス>   ステータスで絞り込む
                                (open|in_progress|completed|archived)
   --inbox                      Inbox のタスクを表示する
+  --all                        全プロジェクト + Inbox を横断表示する
 ```
 
 例:
@@ -144,6 +146,8 @@ task list [オプション]
 task list                        # アクティブプロジェクトのタスクを表示
 task list --status in_progress   # 作業中のタスクのみ表示
 task list --inbox                # Inbox のタスクを表示
+task list --all                  # 全プロジェクト + Inbox を横断表示
+task list --all --status open    # 全プロジェクトの未着手タスクを表示
 ```
 
 ---

--- a/src/cli/Renderer.ts
+++ b/src/cli/Renderer.ts
@@ -90,6 +90,17 @@ export class Renderer {
     console.error(`  対処: ${error.remedy}`);
   }
 
+  renderGroupedTable(groups: { header: string; tasks: Task[] }[]): void {
+    if (groups.length === 0) {
+      console.log(chalk.gray('タスクがありません。'));
+      return;
+    }
+    for (const group of groups) {
+      this.renderTable(group.tasks, group.header);
+      console.log();
+    }
+  }
+
   renderProjectList(
     projects: string[],
     activeProject: string | null,

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -4,7 +4,7 @@ import { TaskManager } from '../../services/TaskManager.js';
 import { GlobalConfigService } from '../../services/GlobalConfigService.js';
 import { FileStorage } from '../../storage/FileStorage.js';
 import { AppError } from '../../types/index.js';
-import type { TaskStatus } from '../../types/index.js';
+import type { Task, TaskStatus } from '../../types/index.js';
 
 export function registerListCommand(program: Command): void {
   program
@@ -15,10 +15,43 @@ export function registerListCommand(program: Command): void {
       'ステータスで絞り込む (open|in_progress|completed|archived)'
     )
     .option('--inbox', 'Inbox のタスクを表示する')
-    .action((options: { status?: string; inbox?: boolean }) => {
+    .option('--all', '全プロジェクトのタスクを表示する')
+    .action((options: { status?: string; inbox?: boolean; all?: boolean }) => {
       const renderer = new Renderer();
       try {
         const configService = new GlobalConfigService();
+        const filter = options.status
+          ? { status: options.status as TaskStatus }
+          : undefined;
+
+        if (options.all) {
+          // --all: 全プロジェクト + Inbox を横断表示
+          const projects = configService.listProjects();
+          const groups: { header: string; tasks: Task[] }[] = [];
+
+          for (const name of projects) {
+            const filePath = configService.getTaskFilePath(name);
+            const tasks = new TaskManager(new FileStorage(filePath)).listTasks(
+              filter
+            );
+            if (tasks.length > 0) {
+              groups.push({ header: `[Project: ${name}]`, tasks });
+            }
+          }
+
+          const inboxPath = configService.getInboxTaskFilePath();
+          const inboxTasks = new TaskManager(
+            new FileStorage(inboxPath)
+          ).listTasks(filter);
+          if (inboxTasks.length > 0) {
+            groups.push({ header: '[Inbox]', tasks: inboxTasks });
+          }
+
+          renderer.renderGroupedTable(groups);
+          return;
+        }
+
+        // 単一プロジェクト / Inbox 表示（既存の動作）
         let activeProject: string | null;
         let filePath: string;
 
@@ -32,11 +65,6 @@ export function registerListCommand(program: Command): void {
 
         const storage = new FileStorage(filePath);
         const manager = new TaskManager(storage);
-
-        const filter = options.status
-          ? { status: options.status as TaskStatus }
-          : undefined;
-
         const tasks = manager.listTasks(filter);
         const header =
           activeProject === null ? '[Inbox]' : `[Project: ${activeProject}]`;

--- a/tests/integration/task-workflow.test.ts
+++ b/tests/integration/task-workflow.test.ts
@@ -76,3 +76,70 @@ describe('task-workflow（統合テスト）', () => {
     expect(() => manager.archiveTask(task.id)).toThrow(AppError);
   });
 });
+
+describe('cross-project list（統合テスト）', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'taskcli-cross-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  function makeStorage(projectName: string): FileStorage {
+    return new FileStorage(join(tmpDir, 'projects', projectName, 'tasks.json'));
+  }
+
+  function makeInboxStorage(): FileStorage {
+    return new FileStorage(join(tmpDir, 'inbox', 'tasks.json'));
+  }
+
+  it('複数プロジェクト + Inbox のタスクを全件取得できる', () => {
+    const managerA = new TaskManager(makeStorage('proj-a'));
+    const managerB = new TaskManager(makeStorage('proj-b'));
+    const inboxManager = new TaskManager(makeInboxStorage());
+
+    managerA.createTask({ title: 'Task in A' });
+    managerB.createTask({ title: 'Task in B' });
+    inboxManager.createTask({ title: 'Task in Inbox' });
+
+    expect(managerA.listTasks()).toHaveLength(1);
+    expect(managerB.listTasks()).toHaveLength(1);
+    expect(inboxManager.listTasks()).toHaveLength(1);
+    expect(managerA.listTasks()[0].title).toBe('Task in A');
+    expect(managerB.listTasks()[0].title).toBe('Task in B');
+    expect(inboxManager.listTasks()[0].title).toBe('Task in Inbox');
+  });
+
+  it('--status in_progress でステータス絞り込みが機能する', () => {
+    const managerA = new TaskManager(makeStorage('proj-a'));
+    const t1 = managerA.createTask({ title: 'Open task' });
+    const t2 = managerA.createTask({ title: 'In progress task' });
+    managerA.startTask(t2.id);
+
+    const allTasks = managerA.listTasks();
+    const filtered = managerA.listTasks({ status: 'in_progress' });
+
+    expect(allTasks).toHaveLength(2);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe(t2.id);
+    // t1 はフィルタ後に含まれない
+    expect(filtered.find((t) => t.id === t1.id)).toBeUndefined();
+  });
+
+  it('タスクが 0 件のプロジェクトはグループに含まれない', () => {
+    const managerA = new TaskManager(makeStorage('proj-a'));
+    const managerB = new TaskManager(makeStorage('proj-b'));
+
+    managerA.createTask({ title: 'Task in A' });
+    // proj-b にはタスクを追加しない
+
+    const tasksA = managerA.listTasks();
+    const tasksB = managerB.listTasks();
+
+    expect(tasksA).toHaveLength(1);
+    expect(tasksB).toHaveLength(0);
+  });
+});

--- a/tests/unit/cli/Renderer.test.ts
+++ b/tests/unit/cli/Renderer.test.ts
@@ -115,6 +115,52 @@ describe('Renderer', () => {
     });
   });
 
+  describe('renderGroupedTable()', () => {
+    it('groups が空の場合「タスクがありません」を表示する', () => {
+      renderer.renderGroupedTable([]);
+      const output = consoleSpy.mock.calls.join('\n');
+      expect(output).toContain('タスクがありません');
+    });
+
+    it('各グループのヘッダーとタスクを表示する', () => {
+      const groups = [
+        {
+          header: '[Project: myapp]',
+          tasks: [makeTask({ id: 1, title: 'Task A' })],
+        },
+        {
+          header: '[Project: personal]',
+          tasks: [makeTask({ id: 2, title: 'Task B' })],
+        },
+      ];
+      renderer.renderGroupedTable(groups);
+      const output = consoleSpy.mock.calls.join('\n');
+      expect(output).toContain('[Project: myapp]');
+      expect(output).toContain('Task A');
+      expect(output).toContain('[Project: personal]');
+      expect(output).toContain('Task B');
+    });
+
+    it('グループ間に空行を挿入する', () => {
+      const groups = [
+        {
+          header: '[Project: myapp]',
+          tasks: [makeTask({ id: 1 })],
+        },
+        {
+          header: '[Inbox]',
+          tasks: [makeTask({ id: 2 })],
+        },
+      ];
+      renderer.renderGroupedTable(groups);
+      // console.log() が空行として呼ばれているか（引数なし呼び出し）
+      const emptyLineCalls = consoleSpy.mock.calls.filter(
+        (call: unknown[]) => call.length === 0 || call[0] === ''
+      );
+      expect(emptyLineCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   describe('renderProjectList()', () => {
     it('プロジェクトがない場合に案内メッセージを表示する', () => {
       renderer.renderProjectList([], null, new Map(), 0);


### PR DESCRIPTION
## Summary

- `task list --all` で全プロジェクト + Inbox のタスクをプロジェクト別グループ形式で横断表示
- `--status` との併用でステータス絞り込みも可能（例: `task list --all --status in_progress`）
- `--all` と `--inbox` の同時指定は `--all` が優先

## 変更内容

- `Renderer.renderGroupedTable()` を追加（既存の `renderTable()` を再利用）
- `list.ts` に `--all` オプションを追加
- ユニットテスト 3 件・統合テスト 3 件追加（74 → 80 テスト）
- README に `--all` オプションを追記

## Test plan

- [x] `npm test` 全 80 テスト合格
- [x] `npm run typecheck` エラーなし
- [x] `npm run lint` エラーなし
- [x] `npm run build` 成功

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)