### PR TITLE
feat(version): task --version 実行時にアップデート通知を表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ task --version
 task --help
 ```
 
+> **アップデート通知**: `task --version` 実行時に新しいバージョンがあると通知が表示されます。
+> ```
+> 0.2.0
+>
+> ✨ アップデートがあります: 0.2.0 → 0.3.0
+>    最新版: https://github.com/kanan4gh/dev-tasks2/releases/latest
+> ```
+
 ---
 
 ## アップデート

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,23 +10,39 @@ import { registerArchiveCommand } from './commands/archive.js';
 import { registerProjectCommand } from './commands/project.js';
 import { registerMoveCommand } from './commands/move.js';
 import { registerInboxCommand } from './commands/inbox.js';
+import { checkUpdate } from '../utils/checkUpdate.js';
 
-const program = new Command();
+const VERSION = '0.2.0';
 
-program
-  .name('task')
-  .description('ターミナルで完結する、開発者向け GTD タスク管理ツール')
-  .version('0.2.0');
+async function main(): Promise<void> {
+  // Commander.js の .version() は同期のみ対応のため、--version を手動ハンドルする
+  if (process.argv.includes('--version') || process.argv.includes('-V')) {
+    console.log(VERSION);
+    const notice = await checkUpdate(VERSION);
+    if (notice) console.log(notice);
+    process.exit(0);
+    return;
+  }
 
-registerAddCommand(program);
-registerListCommand(program);
-registerShowCommand(program);
-registerStartCommand(program);
-registerDoneCommand(program);
-registerDeleteCommand(program);
-registerArchiveCommand(program);
-registerProjectCommand(program);
-registerMoveCommand(program);
-registerInboxCommand(program);
+  const program = new Command();
 
-program.parse(process.argv);
+  program
+    .name('task')
+    .description('ターミナルで完結する、開発者向け GTD タスク管理ツール')
+    .version(VERSION);
+
+  registerAddCommand(program);
+  registerListCommand(program);
+  registerShowCommand(program);
+  registerStartCommand(program);
+  registerDoneCommand(program);
+  registerDeleteCommand(program);
+  registerArchiveCommand(program);
+  registerProjectCommand(program);
+  registerMoveCommand(program);
+  registerInboxCommand(program);
+
+  program.parse(process.argv);
+}
+
+main();

--- a/src/utils/checkUpdate.ts
+++ b/src/utils/checkUpdate.ts
@@ -1,0 +1,55 @@
+const RELEASES_API =
+  'https://api.github.com/repos/kanan4gh/dev-tasks2/releases/latest';
+const RELEASES_URL = 'https://github.com/kanan4gh/dev-tasks2/releases/latest';
+const TIMEOUT_MS = 2000;
+
+// major.minor.patch の数値比較で current < latest かどうかを判定する
+export function isNewer(current: string, latest: string): boolean {
+  const parse = (v: string): [number, number, number] => {
+    const [maj = 0, min = 0, pat = 0] = v.split('.').map(Number);
+    return [maj, min, pat];
+  };
+  const [cMaj, cMin, cPat] = parse(current);
+  const [lMaj, lMin, lPat] = parse(latest);
+  if (lMaj !== cMaj) return lMaj > cMaj;
+  if (lMin !== cMin) return lMin > cMin;
+  return lPat > cPat;
+}
+
+/**
+ * GitHub Releases から最新バージョンを取得し、アップデートがあれば通知文字列を返す。
+ * ネットワークエラー・タイムアウト・404 時は null を返す（クラッシュしない）。
+ */
+export async function checkUpdate(
+  currentVersion: string
+): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(RELEASES_API, { signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { tag_name?: string };
+    const tagName = data.tag_name;
+    if (typeof tagName !== 'string') return null;
+
+    // "v0.3.0" → "0.3.0"
+    const latestVersion = tagName.replace(/^v/, '');
+
+    if (!isNewer(currentVersion, latestVersion)) return null;
+
+    return (
+      `\n✨ アップデートがあります: ${currentVersion} → ${latestVersion}\n` +
+      `   最新版: ${RELEASES_URL}`
+    );
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/utils/checkUpdate.test.ts
+++ b/tests/unit/utils/checkUpdate.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isNewer, checkUpdate } from '../../../src/utils/checkUpdate.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isNewer()', () => {
+  it('latest の major が大きい場合 true を返す', () => {
+    expect(isNewer('1.0.0', '2.0.0')).toBe(true);
+  });
+
+  it('latest の minor が大きい場合 true を返す', () => {
+    expect(isNewer('0.1.0', '0.2.0')).toBe(true);
+  });
+
+  it('latest の patch が大きい場合 true を返す', () => {
+    expect(isNewer('0.1.0', '0.1.1')).toBe(true);
+  });
+
+  it('同じバージョンの場合 false を返す', () => {
+    expect(isNewer('0.2.0', '0.2.0')).toBe(false);
+  });
+
+  it('current の方が大きい場合 false を返す', () => {
+    expect(isNewer('1.0.0', '0.9.9')).toBe(false);
+  });
+});
+
+describe('checkUpdate()', () => {
+  function mockFetch(tagName: string, ok = true): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok,
+        json: () => Promise.resolve({ tag_name: tagName }),
+      })
+    );
+  }
+
+  it('最新バージョンが大きい場合、通知文字列を返す', async () => {
+    mockFetch('v0.3.0');
+    const result = await checkUpdate('0.2.0');
+    expect(result).not.toBeNull();
+    expect(result).toContain('0.2.0 → 0.3.0');
+    expect(result).toContain(
+      'https://github.com/kanan4gh/dev-tasks2/releases/latest'
+    );
+  });
+
+  it('同じバージョンの場合、null を返す', async () => {
+    mockFetch('v0.2.0');
+    expect(await checkUpdate('0.2.0')).toBeNull();
+  });
+
+  it('現在より古いバージョンの場合、null を返す', async () => {
+    mockFetch('v0.1.0');
+    expect(await checkUpdate('0.2.0')).toBeNull();
+  });
+
+  it('tag_name が v プレフィックス付きの場合、正しく除去して比較する', async () => {
+    mockFetch('v1.0.0');
+    const result = await checkUpdate('0.2.0');
+    expect(result).not.toBeNull();
+    expect(result).toContain('0.2.0 → 1.0.0');
+  });
+
+  it('fetch が 404 を返す場合、null を返す', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) })
+    );
+    expect(await checkUpdate('0.2.0')).toBeNull();
+  });
+
+  it('fetch がネットワークエラーの場合、null を返す', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network error'))
+    );
+    expect(await checkUpdate('0.2.0')).toBeNull();
+  });
+
+  it('fetch がタイムアウト（AbortError）の場合、null を返す', async () => {
+    const abortError = new DOMException('aborted', 'AbortError');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+    expect(await checkUpdate('0.2.0')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `task --version` 実行時に GitHub Releases API から最新バージョンを取得し、アップデートがある場合に通知を表示する
- ネットワークエラー・タイムアウト・リリース未作成時は通知をスキップし、通常のバージョン表示のみ行う（終了コード 0）

## 変更内容

- `src/utils/checkUpdate.ts` を新規追加（バージョン取得・比較ロジック）
- `src/cli/index.ts` を `async main()` でラップし `--version` を手動ハンドル（Commander.js の `preAction` は `--version` に反応しないため）
- ユニットテスト 12 件追加（80 → 92 テスト）
- README にアップデート通知の動作例を追記

## 動作例

```
$ task --version
0.2.0

✨ アップデートがあります: 0.2.0 → 0.3.0
   最新版: https://github.com/kanan4gh/dev-tasks2/releases/latest
```

## Test plan

- [x] `npm test` 全 92 テスト合格
- [x] `npm run typecheck` エラーなし
- [x] `npm run lint` エラーなし
- [x] `npm run build` 成功

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)