### PR TITLE
feat: task daily ルーティーン管理機能を追加 (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,43 @@ task done 1
 | `task project remove <名前>` | プロジェクトをリストから削除する（データは保持） |
 | `task inbox` | Inbox モードに切り替える |
 
+### ルーティーン管理
+
+| コマンド | 説明 |
+|---|---|
+| `task daily add <タイトル>` | ルーティーンを登録する |
+| `task daily list` | 今日のルーティーン一覧を表示する |
+| `task daily list --all` | 一時停止中のルーティーンも含めて表示する |
+| `task daily done <id>` | ルーティーンを済にする |
+| `task daily pause <id>` | ルーティーンを一時停止する |
+| `task daily resume <id>` | 一時停止を解除する |
+| `task daily delete <id>` | ルーティーンを削除する |
+| `task daily stats` | 直近7日の達成率を表示する |
+| `task daily reset` | 今日のチェック状態をリセットする |
+
+**表示例 (`task daily list`)**:
+
+```
+[Daily] 2026-03-03
+
+ ID  Status   達成率   Title
+ ─── ──────── ──────── ────────────────────────────────────────
+  1  done      100%    日報を書く
+  2  pending    86%    朝のストレッチ
+  3  pending    57%    読書30分
+```
+
+**表示例 (`task daily stats`)**:
+
+```
+[Daily Stats] 直近7日
+
+ Title          2/25 2/26 2/27 2/28 3/1 3/2 3/3  達成率
+ ────────────── ──── ──── ──── ──── ─── ─── ────  ──────
+ 日報を書く       ✓    ✓    ✓    ✓    ✓   ✓   ✓   100%
+ 朝のストレッチ   ✓    ✓    ✓    ✓    ✓   ✓   -    86%
+```
+
 ---
 
 ### オプション

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,8 @@ src/
 |-----------|----------|-------------|------|
 | グローバル設定 | `~/.task/config.json` | JSON オブジェクト | どのディレクトリからでも参照できるグローバル配置。activeProject の管理に使用 |
 | タスクデータ | `~/.task/projects/<name>/tasks.json` または `~/.task/inbox/tasks.json` | JSON 配列 | 特別なソフトウェア不要・MVP では十分なパフォーマンス |
+| ルーティーン定義 | `~/.task/daily/routines.json` | JSON 配列 | プロジェクト非依存のグローバルルーティーン管理 |
+| ルーティーン実績ログ | `~/.task/daily/log.json` | JSON 配列（DailyLog[]） | 直近30日分の日別 done/pending 実績。30日超の古いログは自動削除 |
 | プロジェクト別設定（P1） | `~/.task/projects/<name>/config.json` | JSON オブジェクト | パーミッション `600` で GitHub Token を保護 |
 | 作業中タスク ID（P1） | Git リポジトリルートの `.taskcli-current` | プレーンテキスト | Git フック（シェルスクリプト）から読み取るため最小形式。`task start` で書き込み、`task done` で削除 |
 
@@ -120,6 +122,9 @@ src/
 ```
 ~/.task/
 ├── config.json                    # グローバル設定（パーミッション: 644）
+├── daily/
+│   ├── routines.json              # ルーティーン定義（パーミッション: 644）
+│   └── log.json                   # 日別 done/pending 実績（最大30日分、パーミッション: 644）
 ├── inbox/
 │   ├── tasks.json                 # Inbox タスクデータ（パーミッション: 644）
 │   └── tasks.json.bak             # 書き込み中のみ存在するバックアップ

--- a/docs/functional-design.md
+++ b/docs/functional-design.md
@@ -113,6 +113,32 @@ interface GlobalConfig {
 
 **旧フォーマットとの互換性**: `projects` が `string[]` 形式の場合、`GlobalConfigStorage.load()` 実行時に自動マイグレーションを行う（`{ name, id }` 形式に変換）。変換結果は次回の書き込みコマンド実行時に `config.json` へ永続化される（遅延書き込み）。
 
+### エンティティ: Routine
+
+ルーティーン定義（`~/.task/daily/routines.json`）。プロジェクトに依存しないグローバルな繰り返しタスク。
+
+```typescript
+interface Routine {
+  id: number;        // 自動採番（1始まり、欠番再利用なし）
+  title: string;     // タイトル
+  paused: boolean;   // 一時停止フラグ（true のとき list から非表示）
+  createdAt: string; // ISO 8601（達成率計算の起算日として使用）
+}
+```
+
+### エンティティ: DailyLog
+
+日別の済/未済実績（`~/.task/daily/log.json`）。直近30日分を配列で保持し、古いログは自動削除。
+
+```typescript
+interface DailyLog {
+  date: string;                              // "YYYY-MM-DD"（ローカルタイムゾーン）
+  entries: Record<number, 'pending' | 'done'>; // routineId → 当日の状態
+}
+```
+
+**自動リセット**: `task daily list` / `done` / `reset` 実行時に日付をチェックし、新しい日であれば今日の空ログを自動作成する（昨日以前のログは保持）。
+
 ### エンティティ: ProjectConfig
 
 プロジェクト別設定（`~/.task/projects/<name>/config.json`）。※ P1 で利用する GitHub 連携設定。
@@ -209,6 +235,19 @@ class CLI {
 | `task project remove <name>` | — | プロジェクト削除（確認プロンプト付き） |
 | `task move <id> <project>` | — | タスクを別プロジェクト（または `inbox`）に移動 |
 | `task inbox` | — | アクティブプロジェクトを解除し Inbox モードに切り替え |
+
+**ルーティーン管理（P0: v1.0 追加実装）**:
+
+| コマンド | 引数 / オプション | 処理概要 |
+|---------|----------------|---------|
+| `task daily add <title>` | — | ルーティーンを登録する |
+| `task daily list` | `--all`（一時停止中も表示） | 今日のルーティーン一覧を表示（達成率高い順、paused は末尾） |
+| `task daily done <id>` | — | ルーティーンを済にする |
+| `task daily pause <id>` | — | ルーティーンを一時停止する（`list` から非表示） |
+| `task daily resume <id>` | — | 一時停止を解除する |
+| `task daily delete <id>` | — | ルーティーンを削除する（実績ログも削除） |
+| `task daily stats` | — | 直近7日の日別達成率テーブルを表示する |
+| `task daily reset` | — | 今日のチェック状態を手動リセットする（確認プロンプト付き） |
 
 **サブコマンド一覧（P1: v1.1）**:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tasks2",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Claude Code book - Chapter 8 template",
   "type": "module",
   "scripts": {

--- a/src/cli/Renderer.ts
+++ b/src/cli/Renderer.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import { AppError } from '../types/index.js';
-import type { Task, TaskStatus } from '../types/index.js';
+import type { Task, TaskStatus, RoutineStats } from '../types/index.js';
+import type { RoutineListItem } from '../services/DailyManager.js';
 
 const MAX_TITLE_LENGTH = 40;
 const MAX_BRANCH_LENGTH = 30;
@@ -111,6 +112,85 @@ export class Renderer {
       this.renderTable(group.tasks, displayHeader, group.projectId);
       console.log();
     }
+  }
+
+  renderDailyList(items: RoutineListItem[], today: string): void {
+    console.log(chalk.bold(`[Daily] ${today}`));
+
+    if (items.length === 0) {
+      console.log(chalk.gray('ルーティーンがありません。'));
+      console.log(chalk.gray('  task daily add <title> で登録してください。'));
+      return;
+    }
+
+    const table = new Table({
+      head: [
+        chalk.bold('ID'),
+        chalk.bold('Status'),
+        chalk.bold('達成率'),
+        chalk.bold('Title'),
+      ],
+      colAligns: ['right', 'left', 'right', 'left'],
+      style: { head: [], border: [] },
+    });
+
+    for (const { routine, status, rate } of items) {
+      const statusStr =
+        status === 'done'
+          ? chalk.green('done')
+          : status === 'paused'
+            ? chalk.gray('paused')
+            : chalk.yellow('pending');
+      const rateStr =
+        rate === null ? chalk.gray('-') : `${Math.round(rate * 100)}%`;
+      table.push([
+        routine.id,
+        statusStr,
+        rateStr,
+        truncate(routine.title, MAX_TITLE_LENGTH),
+      ]);
+    }
+
+    console.log(table.toString());
+  }
+
+  renderDailyStats(stats: RoutineStats[], dates: string[]): void {
+    console.log(chalk.bold('[Daily Stats] 直近7日'));
+
+    if (stats.length === 0) {
+      console.log(chalk.gray('ルーティーンがありません。'));
+      return;
+    }
+
+    const dateHeaders = dates.map((d) => {
+      const [, mm, dd] = d.split('-');
+      return `${parseInt(mm, 10)}/${dd}`;
+    });
+
+    const table = new Table({
+      head: [
+        chalk.bold('Title'),
+        ...dateHeaders.map((d) => chalk.bold(d)),
+        chalk.bold('達成率'),
+      ],
+      colAligns: ['left', ...dates.map(() => 'center' as const), 'right'],
+      style: { head: [], border: [] },
+    });
+
+    for (const { routine, weekHistory, rate } of stats) {
+      const histCells = weekHistory.map((h) => {
+        if (h === 'done') return chalk.green('✓');
+        if (h === 'pending') return chalk.gray('-');
+        return chalk.dim('·');
+      });
+      table.push([
+        truncate(routine.title, 20),
+        ...histCells,
+        `${Math.round(rate * 100)}%`,
+      ]);
+    }
+
+    console.log(table.toString());
   }
 
   renderProjectList(

--- a/src/cli/commands/daily.ts
+++ b/src/cli/commands/daily.ts
@@ -1,0 +1,179 @@
+import type { Command } from 'commander';
+import { DailyStorage } from '../../storage/DailyStorage.js';
+import { DailyManager } from '../../services/DailyManager.js';
+import { Renderer } from '../Renderer.js';
+import { AppError } from '../../types/index.js';
+import { confirm } from '../helpers.js';
+
+function createManager(): DailyManager {
+  return new DailyManager(new DailyStorage());
+}
+
+function parseDailyId(idStr: string): number {
+  const id = parseInt(idStr, 10);
+  if (isNaN(id) || id <= 0) {
+    throw new AppError(
+      '無効な ID です',
+      `"${idStr}" は有効な ID ではありません`,
+      '正の整数を指定してください'
+    );
+  }
+  return id;
+}
+
+export function registerDailyCommand(program: Command): void {
+  const daily = program.command('daily').description('ルーティーンを管理する');
+
+  daily
+    .command('add <title>')
+    .description('ルーティーンを登録する')
+    .action((title: string) => {
+      const renderer = new Renderer();
+      try {
+        const manager = createManager();
+        const routine = manager.addRoutine(title);
+        renderer.renderSuccess(
+          `ルーティーンを追加しました (ID: ${routine.id})`
+        );
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('list')
+    .description('今日のルーティーン一覧を表示する')
+    .option('--all', '一時停止中のルーティーンも表示する')
+    .action((options: { all?: boolean }) => {
+      const renderer = new Renderer();
+      try {
+        const manager = createManager();
+        const items = manager.listRoutines(options.all ?? false);
+        const today = new Date().toISOString().slice(0, 10);
+        renderer.renderDailyList(items, today);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('done <id>')
+    .description('ルーティーンを済にする')
+    .action((idStr: string) => {
+      const renderer = new Renderer();
+      try {
+        const id = parseDailyId(idStr);
+        const manager = createManager();
+        manager.markDone(id);
+        renderer.renderSuccess(`ID: ${id} を済にしました`);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('pause <id>')
+    .description('ルーティーンを一時停止する')
+    .action((idStr: string) => {
+      const renderer = new Renderer();
+      try {
+        const id = parseDailyId(idStr);
+        const manager = createManager();
+        manager.pauseRoutine(id);
+        renderer.renderSuccess(`ID: ${id} を一時停止しました`);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('resume <id>')
+    .description('ルーティーンの一時停止を解除する')
+    .action((idStr: string) => {
+      const renderer = new Renderer();
+      try {
+        const id = parseDailyId(idStr);
+        const manager = createManager();
+        manager.resumeRoutine(id);
+        renderer.renderSuccess(`ID: ${id} の一時停止を解除しました`);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('delete <id>')
+    .description('ルーティーンを削除する')
+    .action(async (idStr: string) => {
+      const renderer = new Renderer();
+      try {
+        const id = parseDailyId(idStr);
+        const ok = await confirm(`ID: ${id} を削除しますか？ (y/N): `);
+        if (!ok) {
+          console.log('キャンセルしました。');
+          return;
+        }
+        const manager = createManager();
+        manager.deleteRoutine(id);
+        renderer.renderSuccess(`ID: ${id} を削除しました`);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('stats')
+    .description('直近7日の達成率を表示する')
+    .action(() => {
+      const renderer = new Renderer();
+      try {
+        const manager = createManager();
+        const stats = manager.getStats();
+        const dates = Array.from({ length: 7 }, (_, i) => {
+          const d = new Date();
+          d.setDate(d.getDate() - (6 - i));
+          return d.toISOString().slice(0, 10);
+        });
+        renderer.renderDailyStats(stats, dates);
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+
+  daily
+    .command('reset')
+    .description('今日のチェック状態をリセットする')
+    .action(async () => {
+      const renderer = new Renderer();
+      try {
+        const ok = await confirm(
+          '今日のチェック状態をリセットしますか？ (y/N): '
+        );
+        if (!ok) {
+          console.log('キャンセルしました。');
+          return;
+        }
+        const manager = createManager();
+        manager.reset();
+        renderer.renderSuccess('今日のチェック状態をリセットしました');
+      } catch (error) {
+        if (error instanceof AppError) renderer.renderError(error);
+        else console.error(error);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,9 +10,10 @@ import { registerArchiveCommand } from './commands/archive.js';
 import { registerProjectCommand } from './commands/project.js';
 import { registerMoveCommand } from './commands/move.js';
 import { registerInboxCommand } from './commands/inbox.js';
+import { registerDailyCommand } from './commands/daily.js';
 import { checkUpdate } from '../utils/checkUpdate.js';
 
-const VERSION = '0.4.0';
+const VERSION = '0.5.0';
 
 async function main(): Promise<void> {
   // Commander.js の .version() は同期のみ対応のため、--version を手動ハンドルする
@@ -41,6 +42,7 @@ async function main(): Promise<void> {
   registerProjectCommand(program);
   registerMoveCommand(program);
   registerInboxCommand(program);
+  registerDailyCommand(program);
 
   program.parse(process.argv);
 }

--- a/src/services/DailyManager.ts
+++ b/src/services/DailyManager.ts
@@ -1,0 +1,218 @@
+import { AppError } from '../types/index.js';
+import type { DailyLog, Routine, RoutineStats } from '../types/index.js';
+import type { DailyStorage } from '../storage/DailyStorage.js';
+
+export interface RoutineListItem {
+  routine: Routine;
+  status: 'pending' | 'done' | 'paused';
+  rate: number | null; // null = paused（表示用 `-`）
+}
+
+export class DailyManager {
+  constructor(private readonly storage: DailyStorage) {}
+
+  private today(): string {
+    const d = new Date();
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private nextId(): number {
+    const routines = this.storage.loadRoutines();
+    if (routines.length === 0) return 1;
+    return Math.max(...routines.map((r) => r.id)) + 1;
+  }
+
+  /**
+   * 日付が変わっていた場合、今日の空ログを新規作成する。
+   */
+  private checkAndResetIfNewDay(): void {
+    const log = this.storage.loadLog();
+    const today = this.today();
+    if (log.date !== today) {
+      const routines = this.storage.loadRoutines();
+      const entries: Record<number, 'pending' | 'done'> = {};
+      for (const r of routines.filter((r) => !r.paused)) {
+        entries[r.id] = 'pending';
+      }
+      this.storage.saveLog({ date: today, entries });
+    }
+  }
+
+  /**
+   * 直近 n 日分の日付文字列を古い順で返す（今日を含む）。
+   */
+  private recentDates(days: number): string[] {
+    const today = this.today();
+    return Array.from({ length: days }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - (days - 1 - i));
+      return d.toISOString().slice(0, 10);
+    });
+  }
+
+  private calcRate(
+    routineId: number,
+    createdAt: string,
+    logs: DailyLog[]
+  ): number {
+    const createdDate = createdAt.slice(0, 10);
+    const relevantLogs = logs.filter((l) => l.date >= createdDate);
+    if (relevantLogs.length === 0) return 0;
+    const doneDays = relevantLogs.filter(
+      (l) => l.entries[routineId] === 'done'
+    ).length;
+    return doneDays / relevantLogs.length;
+  }
+
+  addRoutine(title: string): Routine {
+    const routines = this.storage.loadRoutines();
+    const routine: Routine = {
+      id: this.nextId(),
+      title,
+      paused: false,
+      createdAt: new Date().toISOString(),
+    };
+    routines.push(routine);
+    this.storage.saveRoutines(routines);
+    return routine;
+  }
+
+  /**
+   * ルーティーン一覧を返す。
+   * all=false: アクティブのみ（達成率高い順）
+   * all=true: アクティブ（達成率高い順）+ paused（末尾）
+   */
+  listRoutines(all = false): RoutineListItem[] {
+    this.checkAndResetIfNewDay();
+    const routines = this.storage.loadRoutines();
+    const log = this.storage.loadLog();
+    const recentLogs = this.storage.loadRecentLogs(7);
+
+    const active = routines
+      .filter((r) => !r.paused)
+      .map((routine) => ({
+        routine,
+        status: ((log.entries[routine.id] as 'pending' | 'done') ??
+          'pending') as 'pending' | 'done' | 'paused',
+        rate: this.calcRate(routine.id, routine.createdAt, recentLogs),
+      }))
+      .sort((a, b) => (b.rate ?? 0) - (a.rate ?? 0));
+
+    if (!all) return active;
+
+    const paused = routines
+      .filter((r) => r.paused)
+      .map((routine) => ({
+        routine,
+        status: 'paused' as const,
+        rate: null,
+      }));
+
+    return [...active, ...paused];
+  }
+
+  markDone(id: number): void {
+    this.checkAndResetIfNewDay();
+    const routines = this.storage.loadRoutines();
+    const routine = routines.find((r) => r.id === id);
+    if (!routine) {
+      throw new AppError(
+        'ルーティーンが見つかりません',
+        `ID=${id} のルーティーンは存在しません`,
+        'task daily list で有効な ID を確認してください'
+      );
+    }
+    if (routine.paused) {
+      throw new AppError(
+        'このルーティーンは一時停止中です',
+        `ID=${id} のルーティーンは paused です`,
+        'task daily resume <id> で再開してください'
+      );
+    }
+    const log = this.storage.loadLog();
+    log.entries[id] = 'done';
+    this.storage.saveLog(log);
+  }
+
+  pauseRoutine(id: number): void {
+    const routines = this.storage.loadRoutines();
+    const index = routines.findIndex((r) => r.id === id);
+    if (index === -1) {
+      throw new AppError(
+        'ルーティーンが見つかりません',
+        `ID=${id} のルーティーンは存在しません`,
+        'task daily list --all で有効な ID を確認してください'
+      );
+    }
+    routines[index] = { ...routines[index], paused: true };
+    this.storage.saveRoutines(routines);
+  }
+
+  resumeRoutine(id: number): void {
+    const routines = this.storage.loadRoutines();
+    const index = routines.findIndex((r) => r.id === id);
+    if (index === -1) {
+      throw new AppError(
+        'ルーティーンが見つかりません',
+        `ID=${id} のルーティーンは存在しません`,
+        'task daily list --all で有効な ID を確認してください'
+      );
+    }
+    routines[index] = { ...routines[index], paused: false };
+    this.storage.saveRoutines(routines);
+  }
+
+  deleteRoutine(id: number): void {
+    const routines = this.storage.loadRoutines();
+    const index = routines.findIndex((r) => r.id === id);
+    if (index === -1) {
+      throw new AppError(
+        'ルーティーンが見つかりません',
+        `ID=${id} のルーティーンは存在しません`,
+        'task daily list --all で有効な ID を確認してください'
+      );
+    }
+    routines.splice(index, 1);
+    this.storage.saveRoutines(routines);
+    this.storage.cleanupRoutineFromLogs(id);
+  }
+
+  reset(): void {
+    this.checkAndResetIfNewDay();
+    const log = this.storage.loadLog();
+    const activeIds = new Set(
+      this.storage
+        .loadRoutines()
+        .filter((r) => !r.paused)
+        .map((r) => r.id)
+    );
+    const entries: Record<number, 'pending' | 'done'> = {};
+    for (const key of Object.keys(log.entries)) {
+      const id = Number(key);
+      if (activeIds.has(id)) {
+        entries[id] = 'pending';
+      }
+    }
+    this.storage.saveLog({ ...log, entries });
+  }
+
+  getStats(): RoutineStats[] {
+    const routines = this.storage.loadRoutines().filter((r) => !r.paused);
+    const recentLogs = this.storage.loadRecentLogs(7);
+    const dates = this.recentDates(7);
+
+    return routines.map((routine) => {
+      const weekHistory = dates.map<'done' | 'pending' | 'no-data'>((date) => {
+        if (date < routine.createdAt.slice(0, 10)) return 'no-data';
+        const log = recentLogs.find((l) => l.date === date);
+        if (!log) return 'no-data';
+        return (log.entries[routine.id] as 'pending' | 'done') ?? 'pending';
+      });
+      const rate = this.calcRate(routine.id, routine.createdAt, recentLogs);
+      return { routine, weekHistory, rate };
+    });
+  }
+}

--- a/src/storage/DailyStorage.ts
+++ b/src/storage/DailyStorage.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import type { DailyLog, Routine } from '../types/index.js';
+
+const DAILY_DIR = join(homedir(), '.task', 'daily');
+
+export class DailyStorage {
+  private readonly dailyDir: string;
+  private readonly routinesPath: string;
+  private readonly logPath: string;
+
+  constructor(dailyDir: string = DAILY_DIR) {
+    this.dailyDir = dailyDir;
+    this.routinesPath = join(dailyDir, 'routines.json');
+    this.logPath = join(dailyDir, 'log.json');
+  }
+
+  ensureDirectory(): void {
+    if (!existsSync(this.dailyDir)) {
+      mkdirSync(this.dailyDir, { recursive: true });
+    }
+  }
+
+  loadRoutines(): Routine[] {
+    this.ensureDirectory();
+    if (!existsSync(this.routinesPath)) return [];
+    try {
+      return JSON.parse(readFileSync(this.routinesPath, 'utf-8')) as Routine[];
+    } catch {
+      return [];
+    }
+  }
+
+  saveRoutines(routines: Routine[]): void {
+    this.ensureDirectory();
+    writeFileSync(
+      this.routinesPath,
+      JSON.stringify(routines, null, 2),
+      'utf-8'
+    );
+  }
+
+  /**
+   * 最新の DailyLog を返す。
+   * ログが存在しない場合は今日の空ログを返す。
+   * 最新ログが今日以外の場合もそのまま返す（checkAndResetIfNewDay で判定するため）。
+   */
+  loadLog(): DailyLog {
+    const logs = this.loadAllLogs();
+    if (logs.length === 0) {
+      return { date: todayStr(), entries: {} };
+    }
+    return logs[0]; // 新しい順にソート済み
+  }
+
+  /**
+   * 指定した DailyLog を日付キーで upsert する。
+   * 30日を超えた古いログは自動削除する。
+   */
+  saveLog(log: DailyLog): void {
+    const logs = this.loadAllLogs();
+    const index = logs.findIndex((l) => l.date === log.date);
+    if (index === -1) {
+      logs.push(log);
+    } else {
+      logs[index] = log;
+    }
+    this.saveAllLogs(logs);
+  }
+
+  /**
+   * 直近 n 日分のログを新しい順で返す（stats 用）。
+   */
+  loadRecentLogs(days: number): DailyLog[] {
+    return this.loadAllLogs().slice(0, days);
+  }
+
+  /**
+   * 指定ルーティーン ID のエントリを全ログから削除する（deleteRoutine 用）。
+   */
+  cleanupRoutineFromLogs(routineId: number): void {
+    const logs = this.loadAllLogs();
+    const updated = logs.map((log) => {
+      const entries = { ...log.entries };
+      delete entries[routineId];
+      return { ...log, entries };
+    });
+    this.saveAllLogs(updated);
+  }
+
+  private loadAllLogs(): DailyLog[] {
+    this.ensureDirectory();
+    if (!existsSync(this.logPath)) return [];
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this.logPath, 'utf-8')
+      ) as DailyLog[];
+      return parsed.sort((a, b) => b.date.localeCompare(a.date));
+    } catch {
+      return [];
+    }
+  }
+
+  private saveAllLogs(logs: DailyLog[]): void {
+    this.ensureDirectory();
+    const sorted = logs
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .slice(0, 30); // 30日分のみ保持
+    writeFileSync(this.logPath, JSON.stringify(sorted, null, 2), 'utf-8');
+  }
+}
+
+function todayStr(): string {
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export { DAILY_DIR };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,24 @@ export interface IStorage {
   ensureDirectory(): void;
 }
 
+export interface Routine {
+  id: number;
+  title: string;
+  paused: boolean;
+  createdAt: string;
+}
+
+export interface DailyLog {
+  date: string; // "YYYY-MM-DD"
+  entries: Record<number, 'pending' | 'done'>;
+}
+
+export interface RoutineStats {
+  routine: Routine;
+  weekHistory: ('done' | 'pending' | 'no-data')[]; // 7日分（古い順）
+  rate: number; // 0.0 〜 1.0
+}
+
 export class AppError extends Error {
   constructor(
     message: string,

--- a/tests/integration/daily-workflow.test.ts
+++ b/tests/integration/daily-workflow.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DailyManager } from '../../src/services/DailyManager.js';
+import { DailyStorage } from '../../src/storage/DailyStorage.js';
+
+describe('daily-workflow（統合テスト）', () => {
+  let tmpDir: string;
+  let storage: DailyStorage;
+  let manager: DailyManager;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'taskcli-daily-integration-'));
+    storage = new DailyStorage(tmpDir);
+    manager = new DailyManager(storage);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-03T09:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  it('add → list → done → stats の一連フローが正常に動作する', () => {
+    // add
+    const r1 = manager.addRoutine('日報を書く');
+    const r2 = manager.addRoutine('朝のストレッチ');
+    expect(r1.id).toBe(1);
+    expect(r2.id).toBe(2);
+
+    // list（全て pending）
+    const items = manager.listRoutines();
+    expect(items).toHaveLength(2);
+    expect(items.every((i) => i.status === 'pending')).toBe(true);
+
+    // done
+    manager.markDone(1);
+    const items2 = manager.listRoutines();
+    const done = items2.find((i) => i.routine.id === 1);
+    expect(done?.status).toBe('done');
+
+    // stats（今日のみのデータ）
+    const stats = manager.getStats();
+    expect(stats).toHaveLength(2);
+    const stat1 = stats.find((s) => s.routine.id === 1);
+    expect(stat1?.weekHistory[6]).toBe('done'); // markDone で今日のログが保存済み
+  });
+
+  it('日付をまたいだ場合に自動リセットされる', () => {
+    // 昨日
+    vi.setSystemTime(new Date('2026-03-02T09:00:00Z'));
+    manager.addRoutine('日報');
+    manager.markDone(1);
+
+    const yesterday = storage.loadLog();
+    expect(yesterday.date).toBe('2026-03-02');
+    expect(yesterday.entries[1]).toBe('done');
+
+    // 今日
+    vi.setSystemTime(new Date('2026-03-03T09:00:00Z'));
+    const items = manager.listRoutines(); // → checkAndResetIfNewDay が発動
+
+    expect(items[0].status).toBe('pending'); // 新しい日は pending にリセット
+
+    const today = storage.loadLog();
+    expect(today.date).toBe('2026-03-03');
+    expect(today.entries[1]).toBe('pending');
+
+    // 昨日のログも保持されている
+    const recentLogs = storage.loadRecentLogs(7);
+    const yesterdayLog = recentLogs.find((l) => l.date === '2026-03-02');
+    expect(yesterdayLog?.entries[1]).toBe('done');
+  });
+
+  it('pause → list（非表示）→ list --all（表示）→ resume フロー', () => {
+    manager.addRoutine('アクティブ');
+    manager.addRoutine('一時停止対象');
+    manager.pauseRoutine(2);
+
+    // list（デフォルト）: paused は非表示
+    const items = manager.listRoutines();
+    expect(items).toHaveLength(1);
+    expect(items[0].routine.id).toBe(1);
+
+    // list --all: paused も末尾に表示
+    const allItems = manager.listRoutines(true);
+    expect(allItems).toHaveLength(2);
+    expect(allItems[1].status).toBe('paused');
+    expect(allItems[1].rate).toBeNull();
+
+    // resume
+    manager.resumeRoutine(2);
+    const afterResume = manager.listRoutines();
+    expect(afterResume).toHaveLength(2);
+  });
+});

--- a/tests/unit/services/DailyManager.test.ts
+++ b/tests/unit/services/DailyManager.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DailyManager } from '../../../src/services/DailyManager.js';
+import { DailyStorage } from '../../../src/storage/DailyStorage.js';
+import { AppError } from '../../../src/types/index.js';
+
+describe('DailyManager', () => {
+  let tmpDir: string;
+  let storage: DailyStorage;
+  let manager: DailyManager;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'taskcli-daily-manager-'));
+    storage = new DailyStorage(tmpDir);
+    manager = new DailyManager(storage);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-03T09:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  describe('addRoutine()', () => {
+    it('ID=1 から採番してルーティーンを登録する', () => {
+      const routine = manager.addRoutine('朝のストレッチ');
+      expect(routine.id).toBe(1);
+      expect(routine.title).toBe('朝のストレッチ');
+      expect(routine.paused).toBe(false);
+    });
+
+    it('既存のルーティーンがある場合、次の ID を採番する', () => {
+      manager.addRoutine('ルーティーン1');
+      const r2 = manager.addRoutine('ルーティーン2');
+      expect(r2.id).toBe(2);
+    });
+  });
+
+  describe('checkAndResetIfNewDay() (listRoutines 経由)', () => {
+    it('日付が変わった場合、今日の空ログを作成する', () => {
+      // 昨日のログを作成
+      storage.saveLog({ date: '2026-03-02', entries: { 1: 'done' } });
+      manager.addRoutine('ストレッチ');
+
+      // 今日 list を実行 → checkAndResetIfNewDay が発動
+      manager.listRoutines();
+
+      const log = storage.loadLog();
+      expect(log.date).toBe('2026-03-03');
+      // 今日のエントリは pending で初期化
+      expect(log.entries[1]).toBe('pending');
+    });
+
+    it('同じ日の場合はリセットしない', () => {
+      manager.addRoutine('ストレッチ');
+      manager.markDone(1);
+
+      manager.listRoutines(); // 同日の再実行
+
+      const log = storage.loadLog();
+      expect(log.entries[1]).toBe('done'); // done が保持されている
+    });
+  });
+
+  describe('markDone()', () => {
+    it('正常に done に更新できる', () => {
+      manager.addRoutine('日報');
+      manager.markDone(1);
+
+      const log = storage.loadLog();
+      expect(log.entries[1]).toBe('done');
+    });
+
+    it('存在しない ID の場合 AppError をスローする', () => {
+      expect(() => manager.markDone(99)).toThrow(AppError);
+    });
+
+    it('一時停止中のルーティーンは AppError をスローする', () => {
+      manager.addRoutine('読書');
+      manager.pauseRoutine(1);
+      expect(() => manager.markDone(1)).toThrow(AppError);
+    });
+
+    it('すでに done のルーティーンを再度 done にしてもエラーにならない', () => {
+      manager.addRoutine('日報');
+      manager.markDone(1);
+      expect(() => manager.markDone(1)).not.toThrow();
+    });
+  });
+
+  describe('pauseRoutine() / resumeRoutine()', () => {
+    it('pauseRoutine() でルーティーンを一時停止できる', () => {
+      manager.addRoutine('読書');
+      manager.pauseRoutine(1);
+
+      const routines = storage.loadRoutines();
+      expect(routines[0].paused).toBe(true);
+    });
+
+    it('resumeRoutine() で一時停止を解除できる', () => {
+      manager.addRoutine('読書');
+      manager.pauseRoutine(1);
+      manager.resumeRoutine(1);
+
+      const routines = storage.loadRoutines();
+      expect(routines[0].paused).toBe(false);
+    });
+
+    it('存在しない ID で pauseRoutine は AppError をスローする', () => {
+      expect(() => manager.pauseRoutine(99)).toThrow(AppError);
+    });
+
+    it('存在しない ID で resumeRoutine は AppError をスローする', () => {
+      expect(() => manager.resumeRoutine(99)).toThrow(AppError);
+    });
+  });
+
+  describe('deleteRoutine()', () => {
+    it('ルーティーンを削除できる', () => {
+      manager.addRoutine('削除対象');
+      manager.deleteRoutine(1);
+      expect(storage.loadRoutines()).toHaveLength(0);
+    });
+
+    it('ログの entries からも削除される', () => {
+      manager.addRoutine('削除対象');
+      storage.saveLog({ date: '2026-03-01', entries: { 1: 'done' } });
+      storage.saveLog({ date: '2026-03-02', entries: { 1: 'pending' } });
+
+      manager.deleteRoutine(1);
+
+      const logs = storage.loadRecentLogs(7);
+      for (const log of logs) {
+        expect(log.entries[1]).toBeUndefined();
+      }
+    });
+
+    it('存在しない ID で AppError をスローする', () => {
+      expect(() => manager.deleteRoutine(99)).toThrow(AppError);
+    });
+  });
+
+  describe('reset()', () => {
+    it('今日の全エントリを pending に戻す', () => {
+      manager.addRoutine('日報');
+      manager.addRoutine('ストレッチ');
+      manager.markDone(1);
+      manager.markDone(2);
+
+      manager.reset();
+
+      const log = storage.loadLog();
+      expect(log.entries[1]).toBe('pending');
+      expect(log.entries[2]).toBe('pending');
+    });
+  });
+
+  describe('listRoutines()', () => {
+    it('達成率の高い順にソートされる', () => {
+      // ルーティーン1: 登録日が古い（昨日）→ 昨日 done で達成率 100%
+      vi.setSystemTime(new Date('2026-03-02T09:00:00Z'));
+      manager.addRoutine('高達成率');
+      storage.saveLog({ date: '2026-03-02', entries: { 1: 'done' } });
+
+      // ルーティーン2: 今日登録 → 実績なし 0%
+      vi.setSystemTime(new Date('2026-03-03T09:00:00Z'));
+      manager.addRoutine('低達成率');
+
+      const items = manager.listRoutines();
+      expect(items[0].routine.id).toBe(1);
+      expect(items[1].routine.id).toBe(2);
+    });
+
+    it('paused なルーティーンは返らない（all=false デフォルト）', () => {
+      manager.addRoutine('アクティブ');
+      manager.addRoutine('一時停止');
+      manager.pauseRoutine(2);
+
+      const items = manager.listRoutines();
+      expect(items).toHaveLength(1);
+      expect(items[0].routine.id).toBe(1);
+    });
+
+    it('all=true で paused も末尾に表示される', () => {
+      manager.addRoutine('アクティブ');
+      manager.addRoutine('一時停止');
+      manager.pauseRoutine(2);
+
+      const items = manager.listRoutines(true);
+      expect(items).toHaveLength(2);
+      expect(items[0].status).not.toBe('paused');
+      expect(items[1].status).toBe('paused');
+      expect(items[1].rate).toBeNull();
+    });
+  });
+
+  describe('getStats()', () => {
+    it('直近7日の履歴と達成率が正しく計算される', () => {
+      vi.setSystemTime(new Date('2026-02-25T09:00:00Z'));
+      manager.addRoutine('日報');
+
+      // 2/25 〜 3/3 の 7日間、5日 done
+      const doneDates = [
+        '2026-02-25',
+        '2026-02-26',
+        '2026-02-27',
+        '2026-02-28',
+        '2026-03-01',
+      ];
+      for (const date of doneDates) {
+        storage.saveLog({ date, entries: { 1: 'done' } });
+      }
+      storage.saveLog({ date: '2026-03-02', entries: { 1: 'pending' } });
+
+      vi.setSystemTime(new Date('2026-03-03T09:00:00Z'));
+      const stats = manager.getStats();
+
+      expect(stats).toHaveLength(1);
+      expect(stats[0].routine.id).toBe(1);
+      expect(stats[0].weekHistory).toHaveLength(7);
+      // 今日(3/3)のログは存在しないので no-data
+      expect(stats[0].weekHistory[6]).toBe('no-data');
+      // 3/1 は done
+      expect(stats[0].weekHistory[4]).toBe('done');
+      // 3/2 は pending
+      expect(stats[0].weekHistory[5]).toBe('pending');
+    });
+
+    it('ルーティーン登録前の日は no-data になる', () => {
+      // 今日登録
+      manager.addRoutine('日報');
+
+      const stats = manager.getStats();
+      // 今日以外は全て no-data（登録前）
+      expect(
+        stats[0].weekHistory.slice(0, 6).every((h) => h === 'no-data')
+      ).toBe(true);
+    });
+
+    it('paused なルーティーンは stats に含まれない', () => {
+      manager.addRoutine('アクティブ');
+      manager.addRoutine('一時停止');
+      manager.pauseRoutine(2);
+
+      const stats = manager.getStats();
+      expect(stats).toHaveLength(1);
+      expect(stats[0].routine.id).toBe(1);
+    });
+  });
+});

--- a/tests/unit/storage/DailyStorage.test.ts
+++ b/tests/unit/storage/DailyStorage.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DailyStorage } from '../../../src/storage/DailyStorage.js';
+import type { Routine, DailyLog } from '../../../src/types/index.js';
+
+describe('DailyStorage', () => {
+  let tmpDir: string;
+  let storage: DailyStorage;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'taskcli-daily-'));
+    storage = new DailyStorage(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  describe('loadRoutines()', () => {
+    it('ファイルが存在しない場合は空配列を返す', () => {
+      expect(storage.loadRoutines()).toEqual([]);
+    });
+
+    it('保存したルーティーンを読み込める', () => {
+      const routines: Routine[] = [
+        {
+          id: 1,
+          title: '朝のストレッチ',
+          paused: false,
+          createdAt: '2026-03-03T00:00:00Z',
+        },
+      ];
+      storage.saveRoutines(routines);
+      expect(storage.loadRoutines()).toEqual(routines);
+    });
+  });
+
+  describe('saveRoutines()', () => {
+    it('複数のルーティーンを保存できる', () => {
+      const routines: Routine[] = [
+        {
+          id: 1,
+          title: 'ルーティーン1',
+          paused: false,
+          createdAt: '2026-03-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          title: 'ルーティーン2',
+          paused: true,
+          createdAt: '2026-03-02T00:00:00Z',
+        },
+      ];
+      storage.saveRoutines(routines);
+      expect(storage.loadRoutines()).toEqual(routines);
+    });
+  });
+
+  describe('loadLog()', () => {
+    it('ログが存在しない場合は今日の空ログを返す', () => {
+      const today = new Date().toISOString().slice(0, 10);
+      const log = storage.loadLog();
+      expect(log.date).toBe(today);
+      expect(log.entries).toEqual({});
+    });
+
+    it('最新のログを返す', () => {
+      const older: DailyLog = { date: '2026-03-01', entries: { 1: 'done' } };
+      const newer: DailyLog = { date: '2026-03-03', entries: { 1: 'pending' } };
+      storage.saveLog(older);
+      storage.saveLog(newer);
+      expect(storage.loadLog().date).toBe('2026-03-03');
+    });
+  });
+
+  describe('saveLog()', () => {
+    it('新しいログを追加できる', () => {
+      const log: DailyLog = { date: '2026-03-03', entries: { 1: 'done' } };
+      storage.saveLog(log);
+      expect(storage.loadLog()).toEqual(log);
+    });
+
+    it('同じ日付のログを上書きできる', () => {
+      storage.saveLog({ date: '2026-03-03', entries: { 1: 'pending' } });
+      storage.saveLog({ date: '2026-03-03', entries: { 1: 'done' } });
+      expect(storage.loadLog().entries[1]).toBe('done');
+    });
+
+    it('30件を超えた古いログは削除される', () => {
+      for (let i = 1; i <= 32; i++) {
+        const date = `2026-01-${String(i).padStart(2, '0')}`;
+        storage.saveLog({ date, entries: {} });
+      }
+      const logs = storage.loadRecentLogs(40);
+      expect(logs.length).toBe(30);
+    });
+  });
+
+  describe('loadRecentLogs()', () => {
+    it('新しい順で指定件数を返す', () => {
+      storage.saveLog({ date: '2026-03-01', entries: { 1: 'done' } });
+      storage.saveLog({ date: '2026-03-03', entries: { 1: 'pending' } });
+      storage.saveLog({ date: '2026-03-02', entries: { 1: 'done' } });
+
+      const logs = storage.loadRecentLogs(2);
+      expect(logs).toHaveLength(2);
+      expect(logs[0].date).toBe('2026-03-03');
+      expect(logs[1].date).toBe('2026-03-02');
+    });
+  });
+
+  describe('cleanupRoutineFromLogs()', () => {
+    it('全ログから指定 ID のエントリを削除する', () => {
+      storage.saveLog({
+        date: '2026-03-01',
+        entries: { 1: 'done', 2: 'pending' },
+      });
+      storage.saveLog({
+        date: '2026-03-02',
+        entries: { 1: 'pending', 2: 'done' },
+      });
+
+      storage.cleanupRoutineFromLogs(1);
+
+      const logs = storage.loadRecentLogs(7);
+      for (const log of logs) {
+        expect(log.entries[1]).toBeUndefined();
+        expect(log.entries[2]).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `task daily` サブコマンド群を新規実装（add / list / done / pause / resume / delete / stats / reset）
- `task daily list --all` で一時停止中のルーティーンを末尾に表示
- 日付をまたいだ際に今日のログを自動作成（前日の実績は履歴として保持）
- 実績データは `~/.task/daily/` に保存（最大30日分）

## 変更ファイル

| ファイル | 種別 |
|---|---|
| `src/types/index.ts` | `Routine` / `DailyLog` / `RoutineStats` 型追加 |
| `src/storage/DailyStorage.ts` | 新規：ルーティーン・ログの読み書き |
| `src/services/DailyManager.ts` | 新規：CRUD・日付チェック・統計計算 |
| `src/cli/commands/daily.ts` | 新規：8サブコマンド |
| `src/cli/Renderer.ts` | `renderDailyList` / `renderDailyStats` 追加 |
| `src/cli/index.ts` | `registerDailyCommand` 登録・バージョン 0.5.0 |
| `docs/architecture.md` | `~/.task/daily/` パス追記 |
| `docs/functional-design.md` | `task daily` コマンド群・エンティティ追記 |
| `README.md` | ルーティーン管理セクション追加 |

## Test plan

- [x] 157テスト全通過（`npm test`）
- [x] lint・typecheck・build エラーなし
- [x] `task daily list --all` で paused ルーティーンが末尾に表示されること
- [x] 日付またぎ時の自動リセットが統合テストで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)