### PR TITLE
feat: task daily resume --all で一括再開を追加 (v0.6.1)

### DIFF
--- a/docs/functional-design.md
+++ b/docs/functional-design.md
@@ -245,6 +245,7 @@ class CLI {
 | `task daily done <id>` | — | ルーティーンを済にする |
 | `task daily pause <id>` | — | ルーティーンを一時停止する（`list` から非表示） |
 | `task daily resume <id>` | — | 一時停止を解除する |
+| `task daily resume --all` | — | 一時停止中の全ルーティーンを一括で再開する |
 | `task daily delete <id>` | — | ルーティーンを削除する（実績ログも削除） |
 | `task daily stats` | — | 直近7日の日別達成率テーブルを表示する |
 | `task daily reset` | — | 今日のチェック状態を手動リセットする（確認プロンプト付き） |

--- a/src/cli/commands/daily.ts
+++ b/src/cli/commands/daily.ts
@@ -95,13 +95,30 @@ export function registerDailyCommand(program: Command): void {
     });
 
   daily
-    .command('resume <id>')
-    .description('ルーティーンの一時停止を解除する')
-    .action((idStr: string) => {
+    .command('resume [id]')
+    .description('ルーティーンの一時停止を解除する（--all で一括解除）')
+    .option('--all', '一時停止中の全ルーティーンを一括で再開する')
+    .action((idStr: string | undefined, options: { all?: boolean }) => {
       const renderer = new Renderer();
       try {
-        const id = parseDailyId(idStr);
         const manager = createManager();
+        if (options.all) {
+          const count = manager.resumeAllRoutines();
+          if (count === 0) {
+            console.log('一時停止中のルーティーンはありません');
+          } else {
+            renderer.renderSuccess(`${count} 件のルーティーンを再開しました`);
+          }
+          return;
+        }
+        if (!idStr) {
+          throw new AppError(
+            'ID または --all を指定してください',
+            'ID も --all も指定されていません',
+            'task daily resume <id> または task daily resume --all を使用してください'
+          );
+        }
+        const id = parseDailyId(idStr);
         manager.resumeRoutine(id);
         renderer.renderSuccess(`ID: ${id} の一時停止を解除しました`);
       } catch (error) {

--- a/src/services/DailyManager.ts
+++ b/src/services/DailyManager.ts
@@ -151,6 +151,17 @@ export class DailyManager {
     this.storage.saveRoutines(routines);
   }
 
+  resumeAllRoutines(): number {
+    const routines = this.storage.loadRoutines();
+    const count = routines.filter((r) => r.paused).length;
+    if (count === 0) return 0;
+    const updated = routines.map((r) =>
+      r.paused ? { ...r, paused: false } : r
+    );
+    this.storage.saveRoutines(updated);
+    return count;
+  }
+
   resumeRoutine(id: number): void {
     const routines = this.storage.loadRoutines();
     const index = routines.findIndex((r) => r.id === id);

--- a/tests/unit/services/DailyManager.test.ts
+++ b/tests/unit/services/DailyManager.test.ts
@@ -118,6 +118,31 @@ describe('DailyManager', () => {
     });
   });
 
+  describe('resumeAllRoutines()', () => {
+    it('pause 中の全ルーティーンを resume し件数を返す', () => {
+      manager.addRoutine('読書');
+      manager.addRoutine('運動');
+      manager.addRoutine('料理');
+      manager.pauseRoutine(1);
+      manager.pauseRoutine(3);
+
+      const count = manager.resumeAllRoutines();
+
+      expect(count).toBe(2);
+      const routines = storage.loadRoutines();
+      expect(routines.every((r) => !r.paused)).toBe(true);
+    });
+
+    it('pause 中が 0 件の場合は 0 を返す', () => {
+      manager.addRoutine('読書');
+      manager.addRoutine('運動');
+
+      const count = manager.resumeAllRoutines();
+
+      expect(count).toBe(0);
+    });
+  });
+
   describe('deleteRoutine()', () => {
     it('ルーティーンを削除できる', () => {
       manager.addRoutine('削除対象');


### PR DESCRIPTION
## Summary

- `task daily resume --all` で pause 中の全ルーティーンを一括再開（Issue #13）
- pause 中が 0 件の場合は「一時停止中のルーティーンはありません」と表示
- `task daily resume <id>` の既存動作は変わらず

## Test plan

- [x] `npm test` — 174テスト全通過（新規2テスト追加）
- [x] `npm run lint` — エラーなし
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run build` — ビルド成功
- [ ] 手動 E2E: `task daily pause` で複数停止後、`task daily resume --all` で全件再開を確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)