### PR TITLE
feat: インタラクティブシェルの改善 (Issue #35)

### DIFF
--- a/src/cli/Renderer.ts
+++ b/src/cli/Renderer.ts
@@ -200,6 +200,7 @@ export class Renderer {
   }
 
   renderOnboard(data: OnboardData): void {
+    const cmdPrefix = process.env['TASK_SHELL_MODE'] === '1' ? '' : 'task ';
     const sep = chalk.gray('═'.repeat(40));
     console.log(sep);
     console.log(chalk.bold('  Task Onboard'));
@@ -230,7 +231,9 @@ export class Renderer {
         );
       }
       console.log(
-        chalk.gray('  💡 task schedule <ID> --clear で今すぐ解禁できます')
+        chalk.gray(
+          `  💡 ${cmdPrefix}schedule <ID> --clear で今すぐ解禁できます`
+        )
       );
       console.log();
     }
@@ -254,7 +257,7 @@ export class Renderer {
           `  ${chalk.yellow('○')} ${chalk.gray(`[r${routine.id}]`)} ${routine.title}`
         );
       }
-      console.log(chalk.gray('  💡 task done r<ID> で完了'));
+      console.log(chalk.gray(`  💡 ${cmdPrefix}done r<ID> で完了`));
     }
     console.log();
 
@@ -283,7 +286,9 @@ export class Renderer {
     // 今とりかかるべきタスクのヒント
     if (data.suggestedTasks.length > 0) {
       console.log(
-        chalk.gray('  💡 task start <ID> でタスクを開始、task done <ID> で完了')
+        chalk.gray(
+          `  💡 ${cmdPrefix}start <ID> でタスクを開始、${cmdPrefix}done <ID> で完了`
+        )
       );
     }
     console.log();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { registerOnboardCommand } from './commands/onboard.js';
 import { registerScheduleCommand } from './commands/schedule.js';
 import { registerEditCommand } from './commands/edit.js';
 import { registerShellCommand } from './commands/shell.js';
+import { InteractiveShell } from './shell/InteractiveShell.js';
 import { checkUpdate } from '../utils/checkUpdate.js';
 
 // package.json を単一の正とし、バージョンを動的に読み込む
@@ -25,13 +26,19 @@ const { version: VERSION } = JSON.parse(
 ) as { version: string };
 
 async function main(): Promise<void> {
+  // 引数なしの場合はインタラクティブシェルを起動する
+  if (process.argv.length <= 2) {
+    const shell = new InteractiveShell();
+    await shell.run();
+    return;
+  }
+
   // Commander.js の .version() は同期のみ対応のため、--version を手動ハンドルする
   if (process.argv.includes('--version') || process.argv.includes('-V')) {
     console.log(VERSION);
     const notice = await checkUpdate(VERSION);
     if (notice) console.log(notice);
     process.exit(0);
-    return;
   }
 
   const program = new Command();

--- a/src/cli/shell/InteractiveShell.ts
+++ b/src/cli/shell/InteractiveShell.ts
@@ -138,6 +138,8 @@ export class InteractiveShell {
   }
 
   async run(): Promise<void> {
+    process.env['TASK_SHELL_MODE'] = '1';
+
     const templateProgram = createShellProgram();
 
     const rl = createInterface({
@@ -146,6 +148,7 @@ export class InteractiveShell {
       completer: buildCompleter(templateProgram),
     });
 
+    await this.runCommand(['onboard']);
     rl.setPrompt(getPrompt(this.configService));
     rl.prompt();
 
@@ -176,6 +179,7 @@ export class InteractiveShell {
       });
 
       rl.on('close', () => {
+        delete process.env['TASK_SHELL_MODE'];
         process.stdout.write('\n');
         resolve();
       });

--- a/tests/unit/cli/Renderer.test.ts
+++ b/tests/unit/cli/Renderer.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Renderer } from '../../../src/cli/Renderer.js';
 import { AppError } from '../../../src/types/index.js';
 import type { Task } from '../../../src/types/index.js';
+import type { OnboardData } from '../../../src/usecases/OnboardUseCase.js';
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -27,6 +28,11 @@ describe('Renderer', () => {
     renderer = new Renderer();
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env['TASK_SHELL_MODE'];
+    vi.restoreAllMocks();
   });
 
   describe('renderTable()', () => {
@@ -222,6 +228,43 @@ describe('Renderer', () => {
       expect(output).toContain('personal');
       expect(output).toContain('3 tasks');
       expect(output).toContain('[Inbox]');
+    });
+  });
+
+  describe('renderOnboard() — シェルモード', () => {
+    const minimalOnboardData: OnboardData = {
+      activeProject: 'my-app',
+      pendingRoutineItems: [],
+      routineDoneCount: 0,
+      routineTotalCount: 0,
+      suggestedTasks: [
+        {
+          compositeId: '1-1',
+          status: 'open',
+          title: 'テストタスク',
+          projectName: 'my-app',
+        },
+      ],
+      allGroups: [],
+      upcomingScheduled: [],
+    };
+
+    it('通常モードでは "task start" / "task done" と表示される', () => {
+      delete process.env['TASK_SHELL_MODE'];
+      renderer.renderOnboard(minimalOnboardData);
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('task start');
+      expect(output).toContain('task done');
+    });
+
+    it('シェルモードでは "start" / "done" と表示される（task プレフィックスなし）', () => {
+      process.env['TASK_SHELL_MODE'] = '1';
+      renderer.renderOnboard(minimalOnboardData);
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).not.toContain('task start');
+      expect(output).not.toContain('task done');
+      expect(output).toContain('start <ID>');
+      expect(output).toContain('done <ID>');
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue #35 のフィードバック（1〜3番）を対応。4番は既存の `task move` コマンドと名前衝突のため対応しないことをIssueにコメント済み。

- `task` 引数なし起動でインタラクティブモードに入る（Python/node REPL と同様）
- シェル起動時に `onboard` を自動実行
- シェルモード内の `onboard` ヒントから `task` プレフィックスを除去（`TASK_SHELL_MODE` 環境変数で制御）

## Test plan

- [x] 全テスト通過 (251 tests)
- [x] lint / typecheck / build エラーなし
- [ ] 手動確認: `task` だけで起動してシェルに入り、onboard が自動表示されることを確認
- [ ] 手動確認: onboard のヒントに `task` プレフィックスがないことを確認
- [ ] 手動確認: `task onboard` を単体実行したとき `task` プレフィックス付きで表示されることを確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)